### PR TITLE
fix: workflow step 'build' returns error

### DIFF
--- a/.github/workflows/tag-workflow.yml
+++ b/.github/workflows/tag-workflow.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Install GCC
         uses: egor-tensin/setup-gcc@v1
         with:
@@ -101,10 +101,7 @@ jobs:
         run: sudo apt-get install make ncftp mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config curl clang build-essential hwloc libhwloc-dev wget -y && sudo apt upgrade -y
       - name: Build
         run: |
-          go clean --modcache
-          go version
-          sudo make deps
-          sudo make
+          go clean --modcache && make deps && make
           mkdir ./release && mv ./venus-miner ./release
       - name: Zip Release
         uses: TheDoctor0/zip-release@0.6.0


### PR DESCRIPTION
1. setup go 1.17 
2. fix workflow `build` step failed, which is caused by execution `make` with pre-command 'sudo'
this [document]( https://www.cnblogs.com/doggod/p/13391811.html) tells why can NOT use `sudo` before `make`
