### PR TITLE
fix: git-action: mission colon in auto release workflow

### DIFF
--- a/.github/workflows/tag-workflow.yml
+++ b/.github/workflows/tag-workflow.yml
@@ -67,7 +67,7 @@ jobs:
           echo "::set-output name=pub_method::$pub_method"
           echo "::set-output name=oss_exists::$oss_exists"
           echo "::set-output name=ftp_exists::$ftp_exists"
-          echo "::set-output name=is_tag_create:$is_tag_create"
+          echo "::set-output name=is_tag_create::$is_tag_create"
       - name: show environment
         run: |
           echo event = ${{github.event_name}}


### PR DESCRIPTION
fix: git-action: mission colon in auto release workflow